### PR TITLE
Fixed weird bugs like the following in the input field

### DIFF
--- a/components/Error.vue
+++ b/components/Error.vue
@@ -5,14 +5,13 @@ const errorMessage = useState("errorMessage");
 <template>
   <section class="flex h-screen flex-col justify-center items-center w-full">
     <h1 class="text-4xl">Something's not right 🤔</h1>
-    <h2>
+    <h2 class="text-xl mt-2">
       We got this message -
       <span
         class="
           before:content-[open-quote]
           after:content-[close-quote]
           text-main text-xl
-          mt-2
         "
         >{{ errorMessage }}</span
       >


### PR DESCRIPTION
When server throws a 400 error, the  error ref in the Navbar component kept caching the error request and response returning it even when the input query was a valid location
- Switched to watch() to monitor the error ref

- Fix display issues with the Error component